### PR TITLE
cross compile 32 bit

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -34,7 +34,7 @@ jobs:
           - {
               os: "windows-latest",
               target: "i686-pc-windows-msvc",
-              cross: false,
+              cross: true,
             }
     runs-on: ${{ matrix.info.os }}
     steps:


### PR DESCRIPTION
github actionsでは32ビットのビルドができているのに、Windows端末で`rustup run stable-i686-pc-windows-msvc cargo build --release`でコンパイルしてみても、エラーでビルドできません。