### PR TITLE
remove simplelog crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ rpmalloc = { version = "0.2", optional = true }
 [features]
 default = ["multithreading", "evtx_dump"]
 fast-alloc = ["jemallocator", "rpmalloc"]
-evtx_dump = ["simplelog", "clap", "dialoguer", "indoc", "anyhow"]
+evtx_dump = ["clap", "dialoguer", "indoc", "anyhow"]
 multithreading = ["rayon"]
 
 [dev-dependencies]

--- a/src/bin/evtx_dump.rs
+++ b/src/bin/evtx_dump.rs
@@ -268,14 +268,15 @@ impl EvtxDump {
     }
 
     fn try_to_initialize_logging(&self) -> Result<()> {
-        if let Some(level) = self.verbosity_level {
-            simplelog::WriteLogger::init(
-                level.to_level_filter(),
-                simplelog::Config::default(),
-                io::stderr(),
-            )
-            .with_context(|| "Failed to initialize logging")?;
-        }
+        // hayabusa-evtx does not use logging, so this is commented out.
+        // if let Some(level) = self.verbosity_level {
+        //     simplelog::WriteLogger::init(
+        //         level.to_level_filter(),
+        //         simplelog::Config::default(),
+        //         io::stderr(),
+        //     )
+        //     .with_context(|| "Failed to initialize logging")?;
+        // }
 
         Ok(())
     }

--- a/src/bin/evtx_dump.rs
+++ b/src/bin/evtx_dump.rs
@@ -9,7 +9,6 @@ use encoding::all::encodings;
 use encoding::types::Encoding;
 use evtx::err::Result as EvtxResult;
 use evtx::{EvtxParser, ParserSettings, SerializedEvtxRecord};
-use log::Level;
 use std::fs::{self, File};
 use std::io::{self, BufWriter, Write};
 use std::ops::RangeInclusive;
@@ -39,7 +38,6 @@ struct EvtxDump {
     show_record_number: bool,
     output_format: EvtxOutputFormat,
     output: Box<dyn Write>,
-    verbosity_level: Option<Level>,
     stop_after_error: bool,
     /// When set, only the specified events (offseted reltaive to file) will be outputted.
     ranges: Option<Ranges>,
@@ -117,16 +115,17 @@ impl EvtxDump {
             .value_of("event-ranges")
             .map(|s| Ranges::from_str(s).expect("used validator"));
 
-        let verbosity_level = match matches.occurrences_of("verbose") {
-            0 => None,
-            1 => Some(Level::Info),
-            2 => Some(Level::Debug),
-            3 => Some(Level::Trace),
-            _ => {
-                eprintln!("using more than  -vvv does not affect verbosity level");
-                Some(Level::Trace)
-            }
-        };
+        // hayabusa-evtx does not use logging, so this is commented out.
+        // let verbosity_level = match matches.occurrences_of("verbose") {
+        //     0 => None,
+        //     1 => Some(Level::Info),
+        //     2 => Some(Level::Debug),
+        //     3 => Some(Level::Trace),
+        //     _ => {
+        //         eprintln!("using more than  -vvv does not affect verbosity level");
+        //         Some(Level::Trace)
+        //     }
+        // };
 
         let ansi_codec = encodings()
             .iter()
@@ -156,7 +155,6 @@ impl EvtxDump {
             show_record_number: !no_show_record_number,
             output_format,
             output,
-            verbosity_level,
             stop_after_error,
             ranges: event_ranges,
             display_allocation,


### PR DESCRIPTION
## What Changed

- Excluded simplelog crates that use time crates to pass CI.
