### PR TITLE
fix: quick-xml 0.37.0 compile error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.8.11 - 2024-10-30]
+
+Fixed a compiler bug with `quick-xml` 0.37.0. Updated crates. (#67) (@fukusuket)
+
 ## [0.8.10 - 2024-08-16]
 
 Merged the bug fixes and enhancements in the original [evtx 0.8.3](https://github.com/omerbenamram/evtx/releases/tag/v0.8.3) crate. (@hitenkoku)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,9 +40,9 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
-version = "0.6.15"
+version = "0.6.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526"
+checksum = "23a1e53f0f5d86382dafe1cf314783b2044280f406e7e1506368220ad11b1338"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -55,43 +55,43 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
+checksum = "8365de52b16c035ff4fcafe0092ba9390540e3e352870ac09933bebcaa2c8c56"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb47de1e80c2b463c735db5b217a0ddc39d612e7ac9e2e96a5aed1f57616c1cb"
+checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d36fc52c7f6c869915e99412912f22093507da8d9e942ceaf66fe4b7c14422a"
+checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.4"
+version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8"
+checksum = "2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125"
 dependencies = [
  "anstyle",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.90"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37bf3594c4c988a53154954629820791dde498571819ae4ca50ca811e060cc95"
+checksum = "c042108f3ed77fd83760a5fd79b53be043192bb3b9dba91d8c574c0ada7850c8"
 
 [[package]]
 name = "assert_cmd"
@@ -279,9 +279,9 @@ checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
+checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "comma"
@@ -541,7 +541,7 @@ dependencies = [
 
 [[package]]
 name = "evtx"
-version = "0.8.10"
+version = "0.8.11"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -664,16 +664,15 @@ checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
 
 [[package]]
 name = "insta"
-version = "1.35.1"
+version = "1.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c985c1bef99cf13c58fade470483d81a2bfe846ebde60ed28cc2dddec2df9e2"
+checksum = "a1f72d3e19488cf7d8ea52d2fc0f8754fc933398b337cd3cbdb28aaeb35159ef"
 dependencies = [
  "console",
  "lazy_static",
  "linked-hash-map",
  "serde",
  "similar",
- "yaml-rust",
 ]
 
 [[package]]
@@ -916,9 +915,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.88"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c3a7fc5db1e57d5a779a352c8cdb57b29aa4c40cc69c3a68a7fedc815fbf2f9"
+checksum = "f139b0662de085916d1fb67d2b4169d1addddda1919e696f3252b740b629986e"
 dependencies = [
  "unicode-ident",
 ]
@@ -936,9 +935,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.36.2"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7649a7b4df05aed9ea7ec6f628c67c9953a43869b8bc50929569b2999d443fe"
+checksum = "ffbfb3ddf5364c9cfcd65549a1e7b801d0e8d1b14c1a1590a6408aa93cfbfa84"
 dependencies = [
  "memchr",
 ]
@@ -974,9 +973,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38200e5ee88914975b69f657f0801b6f6dccafd44fd9326302a4aaeecfacb1d8"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1036,9 +1035,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.37"
+version = "0.38.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acb788b847c24f28525660c4d7758620a7210875711f79e7f663cc152726811"
+checksum = "aa260229e6538e52293eeb577aabd09945a09d6d9cc0fc550ed7529056c2e32a"
 dependencies = [
  "bitflags 2.6.0",
  "errno",
@@ -1073,22 +1072,22 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.210"
+version = "1.0.214"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
+checksum = "f55c3193aca71c12ad7890f1785d2b73e1b9f63a0bbc353c08ef26fe03fc56b5"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.210"
+version = "1.0.214"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
+checksum = "de523f781f095e28fa605cdce0f8307e451cc0fd14e2eb4cd2e98a355b147766"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -1155,9 +1154,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.82"
+version = "2.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83540f837a8afc019423a8edb95b52a8effe46957ee402287f4292fae35be021"
+checksum = "5023162dfcd14ef8f32034d8bcd4cc5ddc61ef7a247c024a33e24e1f24d21b56"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1185,22 +1184,22 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "thiserror"
-version = "1.0.64"
+version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d50af8abc119fb8bb6dbabcfa89656f46f84aa0ac7688088608076ad2b459a84"
+checksum = "5d11abd9594d9b38965ef50805c5e469ca9cc6f197f883f717e0269a3057b3d5"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.64"
+version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
+checksum = "ae71770322cbd277e69d762a16c444af02aa0575ac0d174f0b9562d3b37f8602"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -1284,7 +1283,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
  "wasm-bindgen-shared",
 ]
 
@@ -1306,7 +1305,7 @@ checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.85",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1442,15 +1441,6 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
-]
-
-[[package]]
-name = "yaml-rust"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
-dependencies = [
- "linked-hash-map",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/Yamato-Security/hayabusa-evtx"
 license = "MIT"
 readme = "README.md"
 
-version = "0.8.10"
+version = "0.8.11"
 authors = ["Omer Ben-Amram <omerbenamram@gmail.com>, Yamato Security"]
 edition = "2021"
 
@@ -52,7 +52,7 @@ evtx_dump = ["clap", "dialoguer", "indoc", "anyhow"]
 multithreading = ["rayon"]
 
 [dev-dependencies]
-insta = { version = "=1.35.1", features = ["json"] }
+insta = { version = "=1", features = ["json"] }
 pretty_assertions = "1.*"
 criterion = "0.5"
 assert_cmd = "2"

--- a/src/err.rs
+++ b/src/err.rs
@@ -193,8 +193,8 @@ pub enum SerializationError {
     #[error("Error while serializing record")]
     IoError {
         #[from]
-        source: io::Error
-    }
+        source: io::Error,
+    },
 }
 
 #[derive(Debug, Error)]

--- a/src/err.rs
+++ b/src/err.rs
@@ -186,6 +186,15 @@ pub enum SerializationError {
 
     #[error("Unimplemented: {message}")]
     Unimplemented { message: String },
+
+    // TODO オリジナルのevtxリポジトリで修正がはいるまでの、暫定修正
+    // 以下PRにより、Writerが返すErrorの型が変わったため、io:Erorrを追加
+    // https://github.com/tafia/quick-xml/pull/810
+    #[error("Error while serializing record")]
+    IoError {
+        #[from]
+        source: io::Error
+    }
 }
 
 #[derive(Debug, Error)]


### PR DESCRIPTION
## What Changed
- Closed #67 

The following change seems to have caused a change in the type of the Error class returned by the write method.
- https://github.com/tafia/quick-xml/pull/810

## Evidence
```
fukusuke@fukusukenoMacBook-Air hayabusa-evtx % cargo update
    Updating crates.io index
     Locking 16 packages to latest compatible versions
    Updating anstream v0.6.15 -> v0.6.17
    Updating anstyle v1.0.8 -> v1.0.9
    Updating anstyle-parse v0.2.5 -> v0.2.6
    Updating anstyle-query v1.1.1 -> v1.1.2
    Updating anstyle-wincon v3.0.4 -> v3.0.6
    Updating anyhow v1.0.90 -> v1.0.91
    Updating colorchoice v1.0.2 -> v1.0.3
    Updating proc-macro2 v1.0.88 -> v1.0.89
    Updating quick-xml v0.36.2 -> v0.37.0
    Updating regex v1.11.0 -> v1.11.1
    Updating rustix v0.38.37 -> v0.38.38
    Updating serde v1.0.210 -> v1.0.214
    Updating serde_derive v1.0.210 -> v1.0.214
    Updating syn v2.0.82 -> v2.0.85
    Updating thiserror v1.0.64 -> v1.0.65
    Updating thiserror-impl v1.0.64 -> v1.0.65
note: pass `--verbose` to see 17 unchanged dependencies behind latest
fukusuke@fukusukenoMacBook-Air hayabusa-evtx % cargo build --release
   Compiling proc-macro2 v1.0.88
   Compiling unicode-ident v1.0.13
   Compiling libc v0.2.161
   Compiling crossbeam-utils v0.8.20
   Compiling encoding_index_tests v0.1.4
   Compiling autocfg v1.4.0
   Compiling serde v1.0.210
   Compiling utf8parse v0.2.2
   Compiling rustix v0.38.37
   Compiling thiserror v1.0.64
   Compiling syn v1.0.109
   Compiling num-traits v0.2.19
   Compiling crossbeam-epoch v0.9.18
   Compiling anstyle-parse v0.2.5
   Compiling quote v1.0.37
   Compiling syn v2.0.82
   Compiling bitflags v2.6.0
   Compiling core-foundation-sys v0.8.7
   Compiling anstyle-query v1.1.1
   Compiling colorchoice v1.0.2
   Compiling anstyle v1.0.8
   Compiling cfg-if v1.0.0
   Compiling memchr v2.7.4
   Compiling is_terminal_polyfill v1.70.1
   Compiling rayon-core v1.12.1
   Compiling serde_json v1.0.132
   Compiling anstream v0.6.15
   Compiling iana-time-zone v0.1.61
   Compiling crossbeam-deque v0.8.5
   Compiling itoa v1.0.11
   Compiling strsim v0.11.1
   Compiling errno v0.3.9
   Compiling anyhow v1.0.90
   Compiling fastrand v2.1.1
   Compiling ryu v1.0.18
   Compiling lazy_static v1.5.0
   Compiling clap_lex v0.7.2
   Compiling unicode-width v0.1.14
   Compiling once_cell v1.20.2
   Compiling clap_builder v4.5.20
   Compiling console v0.15.8
   Compiling encoding-index-simpchinese v1.20141219.5
   Compiling encoding-index-korean v1.20141219.5
   Compiling encoding-index-singlebyte v1.20141219.5
   Compiling encoding-index-tradchinese v1.20141219.5
   Compiling encoding-index-japanese v1.20141219.5
   Compiling tempfile v3.13.0
   Compiling either v1.13.0
   Compiling foldhash v0.1.3
   Compiling byteorder v1.5.0
   Compiling serde_derive v1.0.210
   Compiling thiserror-impl v1.0.64
   Compiling allocator-api2 v0.2.18
   Compiling bitflags v1.3.2
   Compiling zeroize v1.8.1
   Compiling log v0.4.22
   Compiling equivalent v1.0.1
   Compiling shell-words v1.1.0
   Compiling rayon v1.10.0
   Compiling encoding v0.2.33
   Compiling hashbrown v0.15.0
   Compiling num-derive v0.3.3
   Compiling quick-xml v0.36.2
   Compiling crc32fast v1.4.2
   Compiling indoc v2.0.5
   Compiling dialoguer v0.11.0
   Compiling clap v4.5.20
   Compiling chrono v0.4.38
   Compiling winstructs v0.3.2
   Compiling evtx v0.8.10 (/Users/fukusuke/Scripts/Rust/hayabusa-evtx)
    Finished `release` profile [optimized] target(s) in 27.00s
fukusuke@fukusukenoMacBook-Air hayabusa-evtx %  
```