### PR TITLE
fix: render an empty named <Data> as "" instead of null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.9.8 - 2026-06-27]
+
+- Bug fix: Render a present-but-empty named `<Data Name="X"></Data>` element as `""` instead of `null`, so consumers that distinguish an absent field from a present-but-empty one (e.g. Sigma `field: null` matching) behave correctly. (#90)
+
 ## [0.9.7 - 2026-04-29]
 
 - Bump

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -546,7 +546,7 @@ dependencies = [
 
 [[package]]
 name = "evtx"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/Yamato-Security/hayabusa-evtx"
 license = "MIT"
 readme = "README.md"
 
-version = "0.9.7"
+version = "0.9.8"
 authors = ["Omer Ben-Amram <omerbenamram@gmail.com>, Yamato Security"]
 edition = "2024"
 

--- a/src/json_output.rs
+++ b/src/json_output.rs
@@ -342,9 +342,18 @@ impl BinXmlOutput for JsonOutput {
                 .find(|a| a.name.as_ref().as_str() == "Name")
         {
             let key = name_attr.value.as_ref().as_cow_str().into_owned();
-            if let Some(parent) = self.get_current_parent().as_object_mut()
-                && parent.get(key.as_str()) == Some(&Value::Null)
-            {
+            // A non-object parent here is a structural bug, not a benign skip:
+            // surface it the same way `insert_node_without_attributes` does
+            // rather than silently emitting wrong JSON.
+            let parent = self.get_current_parent().as_object_mut().ok_or_else(|| {
+                SerializationError::JsonStructureError {
+                    message:
+                        "This is a bug - expected parent container to exist, and to be an object type.\
+                         Check that the referencing parent is not `Value::null`"
+                            .to_string(),
+                }
+            })?;
+            if parent.get(key.as_str()) == Some(&Value::Null) {
                 parent.insert(key, Value::String(String::new()));
             }
         }

--- a/src/json_output.rs
+++ b/src/json_output.rs
@@ -326,7 +326,29 @@ impl BinXmlOutput for JsonOutput {
         self.insert_node_with_attributes(element, element_name)
     }
 
-    fn visit_close_element(&mut self, _element: &XmlElement) -> SerializationResult<()> {
+    fn visit_close_element(&mut self, element: &XmlElement) -> SerializationResult<()> {
+        // A named `<Data Name="X"></Data>` that closes with no content must
+        // render as an empty string (`"X": ""`), not `null`. `null` is the
+        // placeholder for an *absent* field, and consumers distinguish a
+        // present-but-empty value from an absent one (e.g. Sigma `field: null`
+        // matching, which should NOT match a present-but-empty field). Emitting
+        // `null` for a present-empty element makes it look absent and changes
+        // detection results. Done before the stack pop, while this Data element
+        // is still the current frame so `get_current_parent()` is its container.
+        if element.name.as_str() == "Data"
+            && let Some(name_attr) = element
+                .attributes
+                .iter()
+                .find(|a| a.name.as_ref().as_str() == "Name")
+        {
+            let key = name_attr.value.as_ref().as_cow_str().into_owned();
+            if let Some(parent) = self.get_current_parent().as_object_mut()
+                && parent.get(key.as_str()) == Some(&Value::Null)
+            {
+                parent.insert(key, Value::String(String::new()));
+            }
+        }
+
         let p = self.stack.pop();
         trace!("visit_close_element: {p:?}");
         Ok(())

--- a/tests/test_empty_data_field.rs
+++ b/tests/test_empty_data_field.rs
@@ -1,0 +1,67 @@
+mod fixtures;
+use fixtures::*;
+
+use evtx::{EvtxParser, ParserSettings};
+use serde_json::Value;
+
+/// Regression test for empty named `<Data>` serialization.
+///
+/// A `<Data Name="X"></Data>` element that is *present but empty* must serialize
+/// to `""` (present, empty), not `null` (which this serializer uses for an
+/// *absent* field). Consumers that distinguish the two — e.g. Sigma
+/// `field: null` matching, which should match only an absent field — otherwise
+/// get wrong results.
+///
+/// The sample is a Windows Firewall EventID-2004 ("a rule has been added") event
+/// for an OpenSSH *service* rule, whose `ApplicationPath` / `ServiceName`
+/// elements are present but empty.
+#[test]
+fn test_empty_named_data_renders_as_empty_string_not_null() {
+    ensure_env_logger_initialized();
+    let evtx_file = include_bytes!("../samples/win_firewall_as_2004_empty_data.evtx");
+    let mut parser = EvtxParser::from_buffer(evtx_file.to_vec())
+        .unwrap()
+        .with_configuration(ParserSettings::new().num_threads(1));
+
+    let record = parser
+        .records_json()
+        .filter_map(Result::ok)
+        .find(|r| {
+            serde_json::from_str::<Value>(&r.data)
+                .ok()
+                .map(|v| {
+                    let eid = &v["Event"]["System"]["EventID"];
+                    eid.as_str() == Some("2004") || eid.as_u64() == Some(2004)
+                })
+                .unwrap_or(false)
+        })
+        .expect("an EventID 2004 firewall-rule-added record to exist in the sample");
+
+    let value: Value = serde_json::from_str(&record.data).expect("record JSON to parse");
+    let event_data = &value["Event"]["EventData"];
+
+    // A present-but-empty named `<Data>` must render as `""`, NOT `null` (which
+    // would make the field look absent to a `field: null` consumer).
+    assert_eq!(
+        event_data["ApplicationPath"].as_str(),
+        Some(""),
+        "empty <Data Name=\"ApplicationPath\"> must render as \"\", got {:?}",
+        event_data["ApplicationPath"]
+    );
+    assert_eq!(
+        event_data["ServiceName"].as_str(),
+        Some(""),
+        "empty <Data Name=\"ServiceName\"> must render as \"\", got {:?}",
+        event_data["ServiceName"]
+    );
+
+    // A non-empty named `<Data>` keeps its concrete value (sanity guard that the
+    // fix only rewrites the empty case).
+    assert!(
+        event_data["ModifyingApplication"]
+            .as_str()
+            .is_some_and(|s| !s.is_empty()),
+        "a non-empty <Data> should keep its value, got {:?}",
+        event_data["ModifyingApplication"]
+    );
+}


### PR DESCRIPTION
## Problem
A named `<Data Name="X"></Data>` element that closes with **no content** is serialized to JSON as `null`:
```json
"ApplicationPath": null
```
But `null` is how this serializer represents an **absent** field — and an empty `<Data>` element is *present-but-empty*, which is semantically different. Downstream consumers that distinguish the two get wrong results.

Concretely, in **hayabusa**: Sigma `field: null` matches an *absent* field. A rule like `win_firewall_as_add_rule.yml` uses `filter_main_null: ApplicationPath: null` to suppress false positives when `ApplicationPath` is absent. For a Windows Firewall **EventID 2004** *service* rule (e.g. OpenSSH `sshd`), the event genuinely contains `<Data Name="ApplicationPath"></Data>` (present, empty — confirmed in the raw XML). Rendering it as `null` makes hayabusa treat the field as absent → the `null` filter wrongly matches → a legitimate "firewall rule added" detection is **silently suppressed**.

## Fix
Render a present-but-empty named `<Data>` as `""`. Done in `visit_close_element`, before the stack pop (while the Data element is still the current frame, so `get_current_parent()` is its container), and scoped to elements named `Data` with a `Name` attribute whose value is still the `null` placeholder. **Other empty elements (`<Correlation/>`, etc.) are unchanged.** This matches how the newer 0.12.x `evtx` line already renders empty `<Data>`.

## Verification
Against a real Windows Firewall EventID-2004 service-rule event:
- `ApplicationPath` (and the other empty `<Data>` fields: `ServiceName`, `RemoteMachineAuthorizationList`, `EmbeddedContext`) now render `""` — was `null`. The raw XML confirms the elements are present-but-empty.
- `<Correlation/>` still renders `null` (non-`Data` empty element untouched).
- `cargo test` green; **no snapshot changes** (existing samples don't contain an empty named `<Data>`), and `cargo fmt --check` + `clippy` clean.

## Note
This restores parity with the 0.12.x parser line. Hayabusa pinning this crate would pick it up on the next rev bump, fixing the under-detection of any rule that uses a `field: null` filter against a present-but-empty field. A regression test using a small firewall sample evtx can be added if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)